### PR TITLE
fix: remove filter functionality

### DIFF
--- a/src/app/common/shared/works-menu/works-menu.component.html
+++ b/src/app/common/shared/works-menu/works-menu.component.html
@@ -2,8 +2,6 @@
   <div class="max-w-base">
     <p-tree
       [value]="nodes"
-      [filter]="true"
-      filterMode="strict"
       selectionMode="single"
       (onNodeSelect)="onNodeSelect($event)"
     >

--- a/src/app/search/presentational/checkbox-works-menu/checkbox-works-menu.component.html
+++ b/src/app/search/presentational/checkbox-works-menu/checkbox-works-menu.component.html
@@ -22,8 +22,6 @@
     <div class="max-w-base">
       <p-tree
         [value]="nodes"
-        [filter]="true"
-        filterMode="strict"
         selectionMode="checkbox"
         (selectionChange)="onSelectionChange($event)"
       >


### PR DESCRIPTION
The PrimeNG filter functionality uses the content of the `label` field for filtering. Because we use `ngx-translate` for translation, the `label` field only contains translation constants. Fixing this by implementing a custom filter logic is not worth it at the moment.